### PR TITLE
Update RISC-V links

### DIFF
--- a/General/overview.xml
+++ b/General/overview.xml
@@ -16,7 +16,7 @@
 	    <page family="RX" html="https://www.renesas.com/document/mat/rx-smart-configurator-users-guide-e-studio"/>
 	    <page family="RL78" html="https://www.renesas.com/document/man/rl78-smart-configurator-users-guide-e-studio"/>
 	    <page family="RH850" html="https://www.renesas.com/document/mat/rh850-smart-configurator-users-guide-e-studio"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/us/en/document/mat/risc-v-mcu-smart-configurator-users-guide-e-studio"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/mat/risc-v-mcu-smart-configurator-users-guide-e-studio"/>
     </userguidee2s>
     <userguidecs>
 	    <page family="RH850" html="https://www.renesas.com/document/mat/rh850-smart-configurator-users-guide-cs"/>
@@ -33,6 +33,6 @@
             <page family="RL78" html="https://www.renesas.com/document/man/smart-configurator-users-manual-rl78-api-reference"/>
             <page family="RH850" html="https://www.renesas.com/document/mat/smart-configurator-users-manual-rh850-api-reference"/>
             <page family="RX" html="https://www.renesas.com/document/mat/smart-configurator-users-manual-rx-api-reference"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/us/en/document/mat/smart-configurator-users-manual-risc-v-mcu-api-reference"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/mat/smart-configurator-users-manual-risc-v-mcu-api-reference"/>
     </apimanual>
 </root>

--- a/General/overview.xml
+++ b/General/overview.xml
@@ -4,19 +4,19 @@
 	    <page family="RH850" html="https://www.renesas.com/rh850-smart-configurator"/>
 	    <page family="RL78" html="https://www.renesas.com/rl78-smart-configurator"/>
 	    <page family="RX" html="https://www.renesas.com/rx-smart-configurator"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/rl78-smart-configurator"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/software-tool/risc-v-smart-configurator"/>
     </scpage>
     <releasenotes>
 	    <page family="RH850" html="https://www.renesas.com/rh850-smart-configurator-release-note"/>
 	    <page family="RL78" html="https://www.renesas.com/rl78-smart-configurator-release-note"/>
 	    <page family="RX" html="https://www.renesas.com/rx-smart-configurator-release-note"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/rl78-smart-configurator-release-note"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/risc-v-smart-configurator-release-note"/>
     </releasenotes>
     <userguidee2s>
 	    <page family="RX" html="https://www.renesas.com/document/mat/rx-smart-configurator-users-guide-e-studio"/>
 	    <page family="RL78" html="https://www.renesas.com/document/man/rl78-smart-configurator-users-guide-e-studio"/>
 	    <page family="RH850" html="https://www.renesas.com/document/mat/rh850-smart-configurator-users-guide-e-studio"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/man/rl78-smart-configurator-users-guide-e-studio"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/us/en/document/mat/risc-v-mcu-smart-configurator-users-guide-e-studio"/>
     </userguidee2s>
     <userguidecs>
 	    <page family="RH850" html="https://www.renesas.com/document/mat/rh850-smart-configurator-users-guide-cs"/>
@@ -27,12 +27,12 @@
 	    <page family="RH850" html="https://www.renesas.com/us/document/mat/rh850-smart-configurator-users-guide-iarew-multi"/>
 	    <page family="RL78" html="https://www.renesas.com/document/mat/rl78-smart-configurator-users-guide-iarew"/>
 	    <page family="RX" html="https://www.renesas.com/document/mat/rx-smart-configurator-users-guide-iarew"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/mat/rl78-smart-configurator-users-guide-iarew"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/mat/risc-v-mcu-smart-configurator-users-guide-iarew"/>
     </userguideiar>
     <apimanual>
             <page family="RL78" html="https://www.renesas.com/document/man/smart-configurator-users-manual-rl78-api-reference"/>
             <page family="RH850" html="https://www.renesas.com/document/mat/smart-configurator-users-manual-rh850-api-reference"/>
             <page family="RX" html="https://www.renesas.com/document/mat/smart-configurator-users-manual-rx-api-reference"/>
-	    <page family="ASSP_RISCV" html="https://www.renesas.com/document/man/smart-configurator-users-manual-rl78-api-reference"/>
+	    <page family="ASSP_RISCV" html="https://www.renesas.com/us/en/document/mat/smart-configurator-users-manual-risc-v-mcu-api-reference"/>
     </apimanual>
 </root>

--- a/General/whats-new.xml
+++ b/General/whats-new.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <whatsnew>
-        <page family="ASSP_RISCV" html="https://www.renesas.com/document/rln/smart-configurator-rl78-v190-release-note"/>
+        <page family="ASSP_RISCV" html="https://www.renesas.com/document/rln/smart-configurator-risc-v-mcu-plug-e-studio-2024-01-smart-configurator-risc-v-mcu-v100-release-note"/>
         <page family="RH850" html="https://www.renesas.com/document/rln/smart-configurator-rh850-v1100-release-note"/>
         <page family="RL78" html="https://www.renesas.com/document/rln/smart-configurator-rl78-v190-release-note"/>
         <page family="RX" html="https://www.renesas.com/document/rln/smart-configurator-rx-v2200-release-note"/>


### PR DESCRIPTION
Updated RISC-V links

- Renesas site RISC-V SC page
- Renesas site RISC-V release notes search filter (error page - accepted error by RISC-V team)
- User guide for RISC-V e2s
- User guide for RISC-V IAREW
- RISC-V API reference
- RISC-V v1.0.0 release note
